### PR TITLE
Fix license copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 yarb00
+Copyright (c) 2024-2025 yarb00
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
License copyright was accidently set to "2025" instead of "2024-2025".