### PR TITLE
Fix "transparent object" bug

### DIFF
--- a/src/PWSandbox.csproj
+++ b/src/PWSandbox.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.4.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PlayForm.cs
+++ b/src/PlayForm.cs
@@ -120,12 +120,17 @@ public partial class PlayForm : Form
 			for (int x = 0; x < mapObjects.GetLength(1); x++)
 				switch (mapObjects[y, x])
 				{
+					case MapObject.Unknown:
+						DrawCell(graphics, (x, y), cellSize, ColorByMapObject[MapObject.Unknown]);
+						break;
+
 					case MapObject.Void:
 						DrawCell(graphics, (x, y), cellSize, ColorByMapObject[MapObject.Void]);
 						break;
 
 					case MapObject.Player:
 						playerPosition ??= (x, y);
+						DrawCell(graphics, (x, y), cellSize, ColorByMapObject[MapObject.Void]);
 						break;
 
 					case MapObject.Finish:
@@ -154,10 +159,6 @@ public partial class PlayForm : Form
 
 					case MapObject.Barrier:
 						DrawCell(graphics, (x, y), cellSize, ColorByMapObject[MapObject.Barrier]);
-						break;
-
-					case MapObject.Unknown:
-						DrawCell(graphics, (x, y), cellSize, ColorByMapObject[MapObject.Unknown]);
 						break;
 				}
 


### PR DESCRIPTION
Fix a bug where nothing was rendered at the player's spawn location, which caused a white square to appear at the player's spawn location when the theme was dark.

Before:
![image](https://github.com/user-attachments/assets/c4491be1-20e7-4372-a3f8-2d4c0cf040b2)

After:
![image](https://github.com/user-attachments/assets/67277756-a9e2-4e2d-970b-eeaf696f7137)
